### PR TITLE
Fix blank screen when the selected namespace is removed

### DIFF
--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -26,8 +26,8 @@
     "angular-messages": "~1.4.9",
     "angular-password": "^1.0.1",
     "angular-sanitize": "~1.4.9",
-    "angular-ui-grid": "^3.1.1",
     "angular-ui-router": "^0.2.18",
+    "angular-vs-repeat": "^1.1.7",
     "d3": "^3.5.16",
     "flux": "^2.1.1",
     "jquery": "~2.2.0",
@@ -38,7 +38,6 @@
     "tether-drop": "^1.4.2"
   },
   "devDependencies": {
-    "angular-vs-repeat": "^1.1.7",
     "autoprefixer": "^6.3.2",
     "babel-core": "^6.4.5",
     "babel-eslint": "^4.1.8",

--- a/src/ui/webpack.config.babel.js
+++ b/src/ui/webpack.config.babel.js
@@ -33,6 +33,7 @@ const webpackConfig = {
             'angular-aria',
             'angular-material',
             'angular-cookies',
+            'angular-messages',
             'angular-password',
             'angular-sanitize',
             'angular-ui-router',
@@ -60,8 +61,8 @@ const webpackConfig = {
             { test: require.resolve('jquery'), loader: 'expose?jQuery' },
             { test: /\.json$/, exclude: /\/(node_modules)\//, loader: 'json' },
             { test: /\.js$/, exclude: /\/(node_modules)\//, loader: 'ng-annotate!babel!eslint' },
-            { test: /\.css/, loader: ExtractTextPlugin.extract('style', 'css', {publicPath:'../../'}) },
-            { test: /\.less/, loader: ExtractTextPlugin.extract('style', 'css!postcss!less', {publicPath:'../../'}) },
+            { test: /\.css/, loader: ExtractTextPlugin.extract('style', 'css', { publicPath: '../../' }) },
+            { test: /\.less/, loader: ExtractTextPlugin.extract('style', 'css!postcss!less', { publicPath: '../../' }) },
             { test: /\.html/, exclude: /\/(components)\//, loader: 'html', include: /\/(app)\// },
             {
                 test: /\.html$/,


### PR DESCRIPTION
Fix a problem by which reinstalling the product having a valid cookie or
removing manually a namespace when it was the selected namespace 
could cause a blank "Instances" screen.

@manolakis 