### PR TITLE
Fix pull policy for elastickube-diagnostics in the default config

### DIFF
--- a/build/deploy.sh
+++ b/build/deploy.sh
@@ -170,7 +170,6 @@ ${MASTER_URL_ENV_SECTION}
           limits:
             cpu: 10m
             memory: 32Mi
-        imagePullPolicy: Never
         volumeMounts:
         - name: elastickube-run
           mountPath: /var/run


### PR DESCRIPTION
There was an error on the RC definition for `elastickube-diagnostics` which prevent the image from being pulled. This prevents the deployment of elastickube using the default:
```curl -s https://elastickube.com | bash```

@osanjuan @albertoarias @arnaud-elasticbox 

