### PR TITLE
Make tests compatible with vanilla unittests and run with py.test

### DIFF
--- a/src/diagnostics/diagnostics.py
+++ b/src/diagnostics/diagnostics.py
@@ -251,9 +251,9 @@ def _document_rc_status(replication_controller):
 def _check_replicaset(settings, namespace, name):
     try:
         document = yield _get_rc(settings, namespace, name)
-    except RuntimeError as e:
-        raise Return(status_error(unicode(e)))
-    except Exception as e:
+    except RuntimeError as ex:
+        raise Return(status_error(unicode(ex)))
+    except Exception as ex:
         logger.exception('Exception detected, %s', type(ex))
         raise Return(status_error('ex {}'.format(unicode(ex))))
 

--- a/src/pytest.ini
+++ b/src/pytest.ini
@@ -1,0 +1,13 @@
+[pytest]
+markers =
+    integration: mark test as integration. It requires a working cluster to test against
+addopts = -m "not integration"
+norecursedirs = .git ui node_modules nginx
+python_paths = /opt/elastickube/src
+pep8maxlinelength = 120
+
+[pylama]
+skip=ui/*
+
+[pylama:pep8]
+max_line_length = 120

--- a/src/tests/api/actions/actions_instances_test.py
+++ b/src/tests/api/actions/actions_instances_test.py
@@ -30,8 +30,8 @@ class ActionsInstancesTests(testing.AsyncTestCase):
     _multiprocess_can_split_ = True
 
     @testing.gen_test(timeout=60)
-    def create_instances_test(self):
-        logging.debug("Start create_instances_test")
+    def test_create_instances(self):
+        logging.debug("Start test_create_instances")
 
         request = yield get_ws_request(self.io_loop)
         connection = yield websocket_connect(request)
@@ -56,7 +56,7 @@ class ActionsInstancesTests(testing.AsyncTestCase):
                         "Message is %s instead of '%s'" % (message["body"]["message"], expected_message))
 
         connection.close()
-        logging.debug("Completed create_instances_test")
+        logging.debug("Completed test_create_instances")
 
 
 if __name__ == "__main__":

--- a/src/tests/api/actions/actions_invitations_test.py
+++ b/src/tests/api/actions/actions_invitations_test.py
@@ -38,8 +38,8 @@ class ActionsInvitationsTests(testing.AsyncTestCase):
         database.Users.remove({"email": email})
 
     @testing.gen_test(timeout=60)
-    def create_invitations_test(self):
-        logging.debug("Start create_invitations_test")
+    def test_create_invitations(self):
+        logging.debug("Start test_create_invitations")
 
         user_email = "test_%s@elasticbox.com" % str(uuid.uuid4())[:10]
         self.addCleanup(self._delete_user, user_email)
@@ -93,11 +93,11 @@ class ActionsInvitationsTests(testing.AsyncTestCase):
         self.assertIsNotNone(new_user)
 
         connection.close()
-        logging.debug("Completed update_settings_test")
+        logging.debug("Completed test_create_invitations")
 
     @testing.gen_test(timeout=60)
-    def update_invitations_test(self):
-        logging.debug("Start update_invitations_test")
+    def test_update_invitations(self):
+        logging.debug("Start test_update_invitations")
 
         request = yield get_ws_request(self.io_loop)
         connection = yield websocket_connect(request)
@@ -120,11 +120,11 @@ class ActionsInvitationsTests(testing.AsyncTestCase):
                         "Message is %s instead of '%s'" % (message["body"]["message"], expected_message))
 
         connection.close()
-        logging.debug("Completed update_invitations_test")
+        logging.debug("Completed test_update_invitations")
 
     @testing.gen_test(timeout=60)
-    def delete_invitations_test(self):
-        logging.debug("Start delete_invitations_test")
+    def test_delete_invitations(self):
+        logging.debug("Start test_delete_invitations")
 
         request = yield get_ws_request(self.io_loop)
         connection = yield websocket_connect(request)
@@ -147,11 +147,11 @@ class ActionsInvitationsTests(testing.AsyncTestCase):
                         "Message is %s instead of '%s'" % (message["body"]["message"], expected_message))
 
         connection.close()
-        logging.debug("Completed delete_invitations_test")
+        logging.debug("Completed test_delete_invitations")
 
     @testing.gen_test(timeout=60)
-    def invite_unauthorized_test(self):
-        logging.debug("Start invite_unauthorized_test")
+    def test_invite_unauthorized(self):
+        logging.debug("Start test_invite_unauthorized")
 
         request = yield get_ws_request(self.io_loop, username="engineer@elasticbox.com")
         connection = yield websocket_connect(request)
@@ -175,7 +175,7 @@ class ActionsInvitationsTests(testing.AsyncTestCase):
                         "Message is %s instead of '%s'" % (message["body"]["message"], expected_message))
 
         connection.close()
-        logging.debug("Completed invite_unauthorized_test")
+        logging.debug("Completed test_invite_unauthorized")
 
 
 if __name__ == "__main__":

--- a/src/tests/api/actions/actions_settings_test.py
+++ b/src/tests/api/actions/actions_settings_test.py
@@ -29,8 +29,8 @@ class ActionsSettingsTests(testing.AsyncTestCase):
     _multiprocess_can_split_ = True
 
     @testing.gen_test(timeout=60)
-    def create_settings_test(self):
-        logging.debug("Start create_settings_test")
+    def test_create_settings(self):
+        logging.debug("Start test_create_settings")
 
         request = yield get_ws_request(self.io_loop)
         connection = yield websocket_connect(request)
@@ -54,11 +54,11 @@ class ActionsSettingsTests(testing.AsyncTestCase):
                         "Message is %s instead of '%s'" % (message["body"]["message"], expected_message))
 
         connection.close()
-        logging.debug("Completed create_settings_test")
+        logging.debug("Completed test_create_settings")
 
     @testing.gen_test(timeout=60)
-    def update_settings_test(self):
-        logging.debug("Start update_settings_test")
+    def test_update_settings(self):
+        logging.debug("Start test_update_settings")
 
         request = yield get_ws_request(self.io_loop)
         connection = yield websocket_connect(request)
@@ -101,11 +101,11 @@ class ActionsSettingsTests(testing.AsyncTestCase):
                             previous_version, message["body"]["metadata"]["resourceVersion"]))
 
         connection.close()
-        logging.debug("Completed update_settings_test")
+        logging.debug("Completed test_update_settings")
 
     @testing.gen_test(timeout=60)
-    def delete_settings_test(self):
-        logging.debug("Start delete_settings_test")
+    def test_delete_settings(self):
+        logging.debug("Start test_delete_settings")
 
         request = yield get_ws_request(self.io_loop)
         connection = yield websocket_connect(request)
@@ -129,11 +129,11 @@ class ActionsSettingsTests(testing.AsyncTestCase):
                         "Message is %s instead of '%s'" % (message["body"]["message"], expected_message))
 
         connection.close()
-        logging.debug("Completed delete_settings_test")
+        logging.debug("Completed test_delete_settings")
 
     @testing.gen_test(timeout=60)
-    def forbidden_update_test(self):
-        logging.debug("Start forbidden_update_test")
+    def test_forbidden_update(self):
+        logging.debug("Start test_forbidden_update")
 
         request = yield get_ws_request(self.io_loop, username="engineer@elasticbox.com")
         connection = yield websocket_connect(request)
@@ -157,7 +157,7 @@ class ActionsSettingsTests(testing.AsyncTestCase):
                         "Message is %s instead of '%s'" % (message["body"]["message"], expected_message))
 
         connection.close()
-        logging.debug("Completed forbidden_update_test")
+        logging.debug("Completed test_forbidden_update")
 
 
 if __name__ == "__main__":

--- a/src/tests/api/actions/actions_users_test.py
+++ b/src/tests/api/actions/actions_users_test.py
@@ -48,8 +48,8 @@ class ActionsUsersTests(testing.AsyncTestCase):
         yield database.Users.remove({"_id": ObjectId(self.user_id)})
 
     @testing.gen_test(timeout=60)
-    def create_user_test(self):
-        logging.debug("Start create_user_test")
+    def test_create_user(self):
+        logging.debug("Start test_create_user")
 
         request = yield get_ws_request(self.io_loop)
         connection = yield websocket_connect(request)
@@ -68,7 +68,7 @@ class ActionsUsersTests(testing.AsyncTestCase):
             message,
             dict(status_code=405, correlation=correlation, operation="create", action="users", body_type=dict))
 
-        logging.debug("Completed create_user_test")
+        logging.debug("Completed test_create_user")
 
 
 if __name__ == "__main__":

--- a/src/tests/api/auth_test.py
+++ b/src/tests/api/auth_test.py
@@ -26,8 +26,8 @@ class AuthTests(testing.AsyncTestCase):
     _multiprocess_can_split_ = True
 
     @testing.gen_test
-    def auth_providers_test(self):
-        logging.debug("Start auth_providers_test")
+    def test_auth_providers(self):
+        logging.debug("Start test_auth_providers")
 
         response = yield AsyncHTTPClient(self.io_loop).fetch("http://localhost/api/v1/auth/providers")
         auth_providers = json.loads(response.body)
@@ -39,11 +39,11 @@ class AuthTests(testing.AsyncTestCase):
                 "Missing property 'regex' in auth password method %s" % auth_providers
             )
 
-        logging.debug("Completed auth_providers_test")
+        logging.debug("Completed test_auth_providers")
 
     @testing.gen_test
-    def signup_disabled_test(self):
-        logging.debug("Start signup_disabled_test")
+    def test_signup_disabled(self):
+        logging.debug("Start test_signup_disabled")
 
         error = None
         try:
@@ -58,11 +58,11 @@ class AuthTests(testing.AsyncTestCase):
         self.assertIsNotNone(error, "No error raised calling /api/v1/auth/signup")
         self.assertEquals(error.code, 403, "/api/v1/auth/signup raised %d instead of 403" % error.code)
 
-        logging.debug("Completed signup_disabled_test")
+        logging.debug("Completed test_signup_disabled")
 
     @testing.gen_test
-    def login_success_test(self):
-        logging.debug("Start login_success_test")
+    def test_login_success(self):
+        logging.debug("Start test_login_success")
 
         response = yield AsyncHTTPClient(self.io_loop).fetch(
             "http://localhost/api/v1/auth/login",
@@ -70,11 +70,11 @@ class AuthTests(testing.AsyncTestCase):
             body=json.dumps(dict(username="operations@elasticbox.com", password="elastickube123")))
 
         self.assertTrue(response.body, "Token not included in response body")
-        logging.debug("Completed login_success_test")
+        logging.debug("Completed test_login_success")
 
     @testing.gen_test
-    def login_wrong_password_test(self):
-        logging.debug("Start login_wrong_password_test")
+    def test_login_wrong_password(self):
+        logging.debug("Start test_login_wrong_password")
 
         error = None
         try:
@@ -88,7 +88,7 @@ class AuthTests(testing.AsyncTestCase):
         self.assertIsNotNone(error, "No error raised calling /api/v1/auth/login")
         self.assertEquals(error.code, 401, "/api/v1/auth/login raised %d instead of 401" % error.code)
 
-        logging.debug("Completed login_wrong_password_test")
+        logging.debug("Completed test_login_wrong_password")
 
 
 if __name__ == '__main__':

--- a/src/tests/api/main_connection_test.py
+++ b/src/tests/api/main_connection_test.py
@@ -30,8 +30,8 @@ class MainConnectionTest(testing.AsyncTestCase):
     _multiprocess_can_split_ = True
 
     @testing.gen_test(timeout=60)
-    def main_connection_test(self):
-        logging.debug("Start main_connection_test")
+    def test_main_connection(self):
+        logging.debug("Start test_main_connection")
 
         request = HTTPRequest(
             "ws://localhost/api/v1/ws",
@@ -61,7 +61,7 @@ class MainConnectionTest(testing.AsyncTestCase):
                         "Message is %s instead of '%s'" % (deserialized_message["error"]["message"], expected_message))
         connection.close()
 
-        logging.debug("Completed main_connection_test")
+        logging.debug("Completed test_main_connection")
 
 
 if __name__ == "__main__":

--- a/src/tests/api/message_validation_test.py
+++ b/src/tests/api/message_validation_test.py
@@ -28,8 +28,8 @@ from tests.api import get_token, wait_message, ELASTICKUBE_TOKEN_HEADER
 class MessageValidationTest(testing.AsyncTestCase):
 
     @testing.gen_test(timeout=60)
-    def message_validation_test(self):
-        logging.debug("Start message_validation_test")
+    def test_message_validation(self):
+        logging.debug("Start test_message_validation")
 
         token = yield get_token(self.io_loop)
         request = HTTPRequest(
@@ -122,7 +122,7 @@ class MessageValidationTest(testing.AsyncTestCase):
                         "Message is %s instead of '%s'" % (deserialized_message['body']["message"], expected_message))
 
         connection.close()
-        logging.debug("Completed message_validation_test")
+        logging.debug("Completed test_message_validation")
 
 
 if __name__ == '__main__':

--- a/src/tests/api/watchers/watch_charts_test.py
+++ b/src/tests/api/watchers/watch_charts_test.py
@@ -30,8 +30,8 @@ class WatchChartsTest(testing.AsyncTestCase):
     _multiprocess_can_split_ = True
 
     @testing.gen_test(timeout=60)
-    def watch_charts_test(self):
-        logging.debug("Start watch_charts_test")
+    def test_watch_charts(self):
+        logging.debug("Start test_watch_charts")
 
         token = yield get_token(self.io_loop)
         request = HTTPRequest(
@@ -104,7 +104,7 @@ class WatchChartsTest(testing.AsyncTestCase):
         self.assertTrue(len(deserialized_message['body'].keys()) == 0, "Body is not empty")
 
         connection.close()
-        logging.debug("Completed watch_charts_test")
+        logging.debug("Completed test_watch_charts")
 
 
 if __name__ == '__main__':

--- a/src/tests/api/watchers/watch_instances_test.py
+++ b/src/tests/api/watchers/watch_instances_test.py
@@ -27,8 +27,8 @@ from tests.api import get_ws_request, validate_response, wait_message
 class WatchInstancesTest(testing.AsyncTestCase):
 
     @testing.gen_test(timeout=60)
-    def watch_instances_test(self):
-        logging.debug("Start watch_instances_test")
+    def test_watch_instances(self):
+        logging.debug("Start test_watch_instances")
 
         request = yield get_ws_request(self.io_loop)
         connection = yield websocket_connect(request)
@@ -154,7 +154,7 @@ class WatchInstancesTest(testing.AsyncTestCase):
                         "Message is %s instead of 'Action not previously watch.'" % message["body"]["message"])
 
         connection.close()
-        logging.debug("Completed watch_instances_test")
+        logging.debug("Completed test_watch_instances")
 
 
 if __name__ == '__main__':

--- a/src/tests/api/watchers/watch_namespaces_test.py
+++ b/src/tests/api/watchers/watch_namespaces_test.py
@@ -28,8 +28,8 @@ from tests.api import get_token, wait_message, ELASTICKUBE_TOKEN_HEADER
 class WatchNamespacesTest(testing.AsyncTestCase):
 
     @testing.gen_test(timeout=60)
-    def watch_namespaces_test(self):
-        logging.debug("Start watch_namespaces_test")
+    def test_watch_namespaces(self):
+        logging.debug("Start test_watch_namespaces")
 
         token = yield get_token(self.io_loop)
         request = HTTPRequest(
@@ -102,7 +102,7 @@ class WatchNamespacesTest(testing.AsyncTestCase):
         self.assertTrue(len(deserialized_message['body'].keys()) == 0, "Body is not empty")
 
         connection.close()
-        logging.debug("Completed watch_namespaces_test")
+        logging.debug("Completed test_watch_namespaces")
 
 
 if __name__ == '__main__':

--- a/src/tests/api/watchers/watch_settings_test.py
+++ b/src/tests/api/watchers/watch_settings_test.py
@@ -30,8 +30,8 @@ class WatchSettingsTest(testing.AsyncTestCase):
     _multiprocess_can_split_ = True
 
     @testing.gen_test(timeout=60)
-    def watch_settings_test(self):
-        logging.debug("Start watch_settings_test")
+    def test_watch_settings(self):
+        logging.debug("Start test_watch_settings")
 
         token = yield get_token(self.io_loop)
         request = HTTPRequest(
@@ -105,7 +105,7 @@ class WatchSettingsTest(testing.AsyncTestCase):
         self.assertTrue(len(deserialized_message['body'].keys()) == 0, "Body is not empty")
 
         connection.close()
-        logging.debug("Completed watch_settings_test")
+        logging.debug("Completed test_watch_settings")
 
 
 if __name__ == '__main__':

--- a/src/tests/api/watchers/watch_users_test.py
+++ b/src/tests/api/watchers/watch_users_test.py
@@ -30,8 +30,8 @@ class WatchUsersTest(testing.AsyncTestCase):
     _multiprocess_can_split_ = True
 
     @testing.gen_test(timeout=60)
-    def watch_users_test(self):
-        logging.debug("Start watch_users_test")
+    def test_watch_users(self):
+        logging.debug("Start test_watch_users")
 
         token = yield get_token(self.io_loop)
         request = HTTPRequest(
@@ -104,7 +104,7 @@ class WatchUsersTest(testing.AsyncTestCase):
         self.assertTrue(len(deserialized_message['body'].keys()) == 0, "Body is not empty")
 
         connection.close()
-        logging.debug("Completed watch_users_test")
+        logging.debug("Completed test_watch_users")
 
 
 if __name__ == '__main__':

--- a/src/tests/diagnostics/diagnostics_test.py
+++ b/src/tests/diagnostics/diagnostics_test.py
@@ -460,15 +460,6 @@ def test_application_html_initializing(http_client, base_url):
 
 
 @pytest.mark.gen_test(run_sync=False)
-def test_application_html_initializing(http_client, base_url):
-    response = yield http_client.fetch(base_url)
-    # assert app is None
-    assert response.code == 200
-    assert 'Diagnostics' in response.body
-    assert 'Initializing' in response.body
-
-
-@pytest.mark.gen_test(run_sync=False)
 def test_application_json_initializing(http_client, base_url, status):
     response = yield http_client.fetch(base_url + '/json')
     assert response.code == 200

--- a/src/tests/diagnostics/diagnostics_test.py
+++ b/src/tests/diagnostics/diagnostics_test.py
@@ -19,12 +19,10 @@ import copy
 import json
 import logging
 import os
-import time
 
 from concurrent.futures import Future
 import mock
 import pytest
-import tornado
 
 from diagnostics import diagnostics
 

--- a/src/tests/pep8_test.py
+++ b/src/tests/pep8_test.py
@@ -25,8 +25,8 @@ class Pep8Test(testing.AsyncTestCase):
 
     _multiprocess_can_split_ = True
 
-    def pep8_test(self):
-        logging.debug("Start pep8_test")
+    def test_pep8(self):
+        logging.debug("Start test_pep8")
 
         src_folder = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         command = " ".join(["pep8", "--max-line-length=120 --exclude=node_modules", src_folder]).split()
@@ -35,7 +35,7 @@ class Pep8Test(testing.AsyncTestCase):
 
         self.assertFalse(errors is not None and errors.strip() != '', "Pep8 errors %s" % errors)
 
-        logging.debug("Completed pep8_test")
+        logging.debug("Completed test_pep8")
 
 
 if __name__ == "__main__":

--- a/src/tests/requirements.txt
+++ b/src/tests/requirements.txt
@@ -7,6 +7,12 @@ passlib
 pep8
 pycurl
 PyJWT
+pylama
 pylint
 pytest
+pytest-cache
+pytest-pep8
+pytest-pythonpath
+pytest-tornado
+pytest-xdist
 tornado

--- a/src/tests/runtests.py
+++ b/src/tests/runtests.py
@@ -19,8 +19,7 @@ import argparse
 import logging
 import sys
 
-import nose
-from nose.plugins.multiprocess import MultiProcess
+import pytest
 
 logging.basicConfig(stream=sys.stdout, level=logging.ERROR)
 
@@ -54,4 +53,4 @@ def parse_arguments():
     return options
 
 if __name__ == "__main__":
-    nose.main(parse_arguments(), plugins=[MultiProcess()])
+    pytest.main()


### PR DESCRIPTION
Most of the changes are the renaming of function tests and files to fit the unittest standard (nose is more relaxed in the naming).

* py.test in src or src/tests just works
* Tests can be run by `python runtests.py`
* Make parallel tests by -n NUM_WORKERS with py.test
* py.test -f waits for file changes to rerun only failed tests

@arnaud-elasticbox What do you think?