### PR TITLE
Add support for any DNS system in Diagnostics

### DIFF
--- a/build/kubegrunt/elastickube/elastickube-server-rc.yaml
+++ b/build/kubegrunt/elastickube/elastickube-server-rc.yaml
@@ -65,7 +65,7 @@ spec:
           value: "1"
         resources:
           limits:
-            cpu: 10m
+            cpu: 20m
             memory: 32Mi
         imagePullPolicy: Never
         volumeMounts:

--- a/src/diagnostics/templates/diagnostics.html
+++ b/src/diagnostics/templates/diagnostics.html
@@ -91,7 +91,7 @@
                         {% module StateUI(status['kube-system.elastickube-server'], 'Chart Service') %}
                         {% module StateUI(status['internet'], 'Internet Connection') %}
                         {% module StateUI(status['heapster'], 'Heapster Connection') %}
-                        {% module StateUI(status['kube-system.kube-dns-v9'], 'Kubernetes DNS') %}
+                        {% module StateUI(status['dns'], 'Kubernetes DNS') %}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
* Check for kubernetes.default instead of looking for the pod
* Fix tests of heapster

It also fixes #61 

@arnaud-elasticbox @albertoarias 