### PR TITLE
Fix Query.insert when manipulate is False

### DIFF
--- a/src/data/query.py
+++ b/src/data/query.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 import time
 
+from bson.objectid import ObjectId
 from pymongo.errors import PyMongoError
 from tornado.gen import coroutine, Return
 
@@ -79,6 +80,8 @@ class Query(object):
                 deletionTimestamp=None
             )
 
+        if '_id' not in document and not self.manipulate:
+            document['_id'] = ObjectId()
         document_id = yield self.database[self.collection].insert(document, manipulate=self.manipulate)
         inserted_document = yield self.database[self.collection].find_one(
             {"_id": document_id},


### PR DESCRIPTION
@arnaud-elasticbox @albertoarias @davisein 

At ```Query.insert``` method, the insert sentence is returning ```None```, instead of ```_id``` value, when ```manipulate``` is ```False```. This is because the default value for manipulate on insert method is True. Motor documentation says:

> If manipulate is False and the document(s) does not include an "_id" one will be added by the server. The server does not return the "_id" it created so None is returned.