### PR TITLE
Handle errors when Pods logs are not yet available.

### DIFF
--- a/src/api/kube/pods.py
+++ b/src/api/kube/pods.py
@@ -124,11 +124,14 @@ class Pods(NamespacedResource):
             if key not in url_path:
                 params[key] = kwargs[key]
 
-        result = yield self.api.http_client.request(url, **params)
-
         logs = dict(kind="LogList", items=[], metadata=dict(resourceVersion=time.time()))
+        lines = []
+        try:
+            result = yield self.api.http_client.request(url, **params)
+            lines = result.body.splitlines()
+        except HTTPError as http_error:
+            logging.exception("Failed to retrieve Pods logs")
 
-        lines = result.body.splitlines()
         for line in lines:
             text = line
             timestamp = None


### PR DESCRIPTION
@davisein @arnaud-elasticbox 

When Pods are still not ready, retrieving logs was raising an unhandled Bad Request exception.