### PR TITLE
Fix error messages while image is deploying and container is not ready

### DIFF
--- a/src/ui/app/instances/ek-instance-containers/ek-instance-containers.html
+++ b/src/ui/app/instances/ek-instance-containers/ek-instance-containers.html
@@ -1,2 +1,2 @@
-<ek-instance-container-block ng-repeat="container in ctrl.instance.status.containerStatuses track by container.containerID"
+<ek-instance-container-block ng-repeat="container in ctrl.instance.status.containerStatuses track by $index"
                              container="container"></ek-instance-container-block>

--- a/src/ui/app/instances/ek-instance-overview-containers/ek-instance-overview-containers.html
+++ b/src/ui/app/instances/ek-instance-overview-containers/ek-instance-overview-containers.html
@@ -1,7 +1,7 @@
 <h3>Containers</h3>
 <div layout="row" layout-wrap layout-align="space-around center">
     <div class="ek-instance-overview-containers__container"
-         ng-repeat="container in ctrl.instance.status.containerStatuses track by container.containerID">
+         ng-repeat="container in ctrl.instance.status.containerStatuses track by $index">
         <ek-instance-container-chart container="container"></ek-instance-container-chart>
     </div>
 </div>


### PR DESCRIPTION
When de container is not ready, the containerID is not populated so sometimes could exist duplicated keys when tracking. 

@manolakis 