### PR TITLE
SAML improvements

### DIFF
--- a/src/api/schemas/user.json
+++ b/src/api/schemas/user.json
@@ -35,6 +35,9 @@
     "google_id": {
       "type": "string"
     },
+    "saml_id": {
+      "type": "string"
+    },
     "icon": {
       "type": "string",
       "maxLength": 256

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -24,8 +24,8 @@ from tornado.web import Application
 
 from api.v1 import configure, initialize
 from api.v1.main import MainWebSocketHandler
-from api.v1.auth import AuthProvidersHandler, ChangePasswordHandler, GoogleOAuth2LoginHandler, \
-    PasswordHandler, RequestInviteHandler, ResetPasswordHandler, Saml2LoginHandler, SignupHandler
+from api.v1.auth import AuthProvidersHandler, ChangePasswordHandler, GoogleOAuth2LoginHandler, PasswordHandler, \
+    RequestInviteHandler, ResetPasswordHandler, Saml2LoginHandler, Saml2MetadataHandler, SignupHandler
 from api.v1.icons import IconGenerator
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG, format='%(asctime)s %(message)s')
@@ -58,6 +58,7 @@ def start_server(future):
         (r"/api/v1/auth/login", PasswordHandler),
         (r"/api/v1/auth/google", GoogleOAuth2LoginHandler),
         (r"/api/v1/auth/saml", Saml2LoginHandler),
+        (r"/api/v1/auth/saml/metadata", Saml2MetadataHandler),
         (r"/api/v1/ws", MainWebSocketHandler),
         (r"/icons/(?P<entity_id>[^\/]+)\/(?P<chart_id>[^\/]+)", IconGenerator)
     ]

--- a/src/api/v1/actions/emails.py
+++ b/src/api/v1/actions/emails.py
@@ -128,9 +128,9 @@ def send_reset_password_link(smtp_config, user_data, settings, threadpool=None):
 
 def send_request_invite_email_sync(smtp_config, admin_email, origin_user, invite_address, settings):
     try:
-        name_escaped = cgi.escape(origin_user['name'])
-        email_escaped = cgi.escape(origin_user['email'], quote=True)
-        invite_address_escaped = cgi.escape(invite_address)
+        name_escaped = cgi.escape(origin_user['name'].encode('utf8'))
+        email_escaped = cgi.escape(origin_user['email'].encode('utf8'), quote=True)
+        invite_address_escaped = cgi.escape(invite_address.encode('utf8'))
 
         email_body = REQUEST_INVITE_TEMPLATE.format(
             origin_name=name_escaped,

--- a/src/ui/app/admin/ek-admin-settings/ek-admin-settings.html
+++ b/src/ui/app/admin/ek-admin-settings/ek-admin-settings.html
@@ -85,7 +85,7 @@
                     </div>
                 </div>
                 <div class="ek-admin-settings__authentication__methods__configuration" ng-if="ctrl.auth_sso === 'saml'">
-                    <div class="ek-admin-settings__subtitle ek-admin-settings__subtitle--required">Metadata document</div>
+                    <div class="ek-admin-settings__subtitle ek-admin-settings__subtitle--required">IdP Metadata</div>
 
                     <div layout="row" layout-align="start center" ng-hide="ctrl.auth.saml_data.idp_domain">
                         <input id="fileMetadata" name="file" type="file" size-limit="10240" ek-on-file-change="ctrl.readMetadata"
@@ -113,9 +113,17 @@
                         {{:: ctrl.metadata_error }}
                     </div>
 
-                    <div class="ek-admin-settings__subtitle ek-admin-settings__subtitle">Redirect URI</div>
-                    <input type="text" class="ek-admin-settings__input ek-admin-settings__input--long ek-admin-settings__input--readonly ek-input"
-                           ng-value="ctrl.hostname + '/api/v1/auth/saml'" ng-readonly="true">
+                    <div class="ek-admin-settings__subtitle ek-admin-settings__subtitle">SP Metadata</div>
+
+                    <div class="ek-admin-settings__authentication__methods__configuration__file" layout="row" layout-align="space-between center">
+                        <div layout="row" layout-align="start center">
+                            <div>
+                                <p>elastickube_sp.xml</p>
+                            </div>    
+                        </div>
+                        
+                        <a class="ek-admin-settings__button--file ek-button ek-button md-button md-ink-ripple" ng-href="/api/v1/auth/saml/metadata" download="elastickube_sp.xml">Download</a>
+                    </div>
 
                 </div>
             </md-radio-group>

--- a/src/ui/app/login/ek-request-invite/ek-request-invite.html
+++ b/src/ui/app/login/ek-request-invite/ek-request-invite.html
@@ -1,6 +1,6 @@
 <h2 class="ek-request-invite__title">Request Invite</h2>
 <p class="ek-request-invite__legend" ng-if="!ctrl.account">Enter your email to request an invite from your administrator.</p>
-<p class="ek-reset-password__legend" ng-if="ctrl.account">Your account <b>{{ ctrl.account }}</b> has not yet been enabled. Request an invite from your administrator to continue.</p>
+<p class="ek-reset-password__legend" ng-if="ctrl.account">Your account <b>{{ ctrl.name }} ({{ ctrl.account }})</b> has not yet been enabled. Request an invite from your administrator to continue.</p>
 
 <form ng-submit="ctrl.submit()" class="ek-request-invite__form" name="requestInviteForm">
     <div layout="row" ng-if="!ctrl.account">


### PR DESCRIPTION
@albertoarias @arnaud-elasticbox @mattnickles 

These are the changes done:
- Autogenerate the SP metadata file, and added button to download it.
- The SP EntityID now is only the hostname domain, we are removed the protocol (http or https).
- Require that IdP message are signed.
- NameIdFormat changed from "emailAddress" to "unspecified": **_Now it's required that IdP send the email in the SAML response attributes._**
- Saving SAML NameID on User document.

This is the current style:
![screen shot 2016-07-22 at 3 35 10 pm](https://cloud.githubusercontent.com/assets/10052312/17058737/0c96477a-5022-11e6-8e93-357009b991b9.png)
