### PR TITLE
Fix CairoSVG library dependency to latest compatible version 

### DIFF
--- a/src/Dockerfile-api
+++ b/src/Dockerfile-api
@@ -11,7 +11,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927 && \
 
 RUN apt-get update -y && \
     apt-get install -y --force-yes mongodb-org-shell libxmlsec1-dev && \
-    pip install --no-compile tornado motor PyJWT pycurl cairosvg futures passlib python-saml  && \
+    pip install --no-compile tornado motor PyJWT pycurl "cairosvg>=1.0,<2.0" futures passlib python-saml  && \
     apt-get clean && \
     apt-get autoremove -y
 

--- a/src/api/v1/actions/namespaces.py
+++ b/src/api/v1/actions/namespaces.py
@@ -100,7 +100,7 @@ class NamespacesActions(object):
                     "ts": {"$gt": last_timestamp},
                     "op": {"$in": ["i"]},
                     "ns": {"$in": ["elastickube.Namespaces"]}
-                }, tailable=True, await_data=True)
+                }, cursor_type=pymongo.CursorType.TAILABLE_AWAIT)
 
                 cursor.add_option(8)
                 logging.debug("Tailable cursor recreated.")

--- a/src/api/v1/main.py
+++ b/src/api/v1/main.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import logging
+import httplib
 
 from bson.json_util import loads
 from pymongo.errors import DuplicateKeyError, PyMongoError
@@ -69,6 +70,8 @@ class MainWebSocketHandler(SecureWebSocketHandler):
             self.build_actions_lookup()
 
         if not self.user:
+            self.write_message({"error": {"message": "Invalid token."}})
+            self.close(httplib.UNAUTHORIZED, "Invalid token.")
             raise Return()
 
         request = yield self.validate_message(message)

--- a/src/api/v1/sync/metrics.py
+++ b/src/api/v1/sync/metrics.py
@@ -93,10 +93,7 @@ class SyncMetrics(object):
             for timestamp in timestamps:
                 for item in cpu_limits:
                     if item["timestamp"] == timestamp:
-                        if metric["timestamps"].keys() == 0:
-                            metric["timestamps"] = {timestamp: {"cpu_request": item["value"]}}
-                        else:
-                            metric["timestamps"].update({timestamp: {"cpu_request": item["value"]}})
+                        metric["timestamps"][timestamp] = {"cpu_request": item["value"]}
 
         if "memory/request" in namespace_metrics:
             mem_limit_response = yield self.settings["heapster"].namespaces.metric("memory/request",
@@ -114,7 +111,7 @@ class SyncMetrics(object):
             for timestamp in metric["timestamps"].keys():
                 for item in cpu_usages:
                     if item["timestamp"] == timestamp:
-                        metric["timestamps"][timestamp].update({"cpu_usage": item["value"]})
+                        metric["timestamps"][timestamp]["cpu_usage"] = item["value"]
 
         if "memory/usage" in namespace_metrics:
             mem_usage_response = yield self.settings["heapster"].namespaces.metric("memory/usage", name=namespace_name)

--- a/src/data/watch.py
+++ b/src/data/watch.py
@@ -77,7 +77,7 @@ def start_monitor(client):
                     'ts': {'$gt': last_timestamp},
                     'op': {'$in': WATCHABLE_OPERATIONS},
                     'ns': {'$in': WATCHABLE_COLLECTIONS}
-                }, tailable=True, await_data=True)
+                }, cursor_type=pymongo.CursorType.TAILABLE_AWAIT)
 
                 cursor.add_option(8)
                 logging.debug('Tailable cursor recreated.')


### PR DESCRIPTION
For Python 2.7 the latest CairoSVG compatible version is fixed to 1.x, since version 2.x is for Python 3.x only.

@davisein, 👍?