### PR TITLE
Fix user role filtered namespace

### DIFF
--- a/src/api/v1/watchers/__init__.py
+++ b/src/api/v1/watchers/__init__.py
@@ -26,8 +26,7 @@ def filter_namespaces(data, user, _message):
         else:
             if "members" not in data or user["username"] not in data["members"]:
                 return None
-    else:
-        return data
+    return data
 
 
 def filter_metrics(data, user, message):


### PR DESCRIPTION
I found that if all condition are False `filter_namespaces` function will not return anything. By this PR, It should catch by last return data  